### PR TITLE
Fixed specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,21 +61,7 @@ jobs:
 workflows:
   run-tests:
     jobs:
-      - build:
-          name: run-tests-ruby-2.4
-          executor: ruby-24
-      - build:
-          name: run-tests-ruby-2.5
-          executor: ruby-25
-          requires:
-            - run-tests-ruby-2.4
-      - build:
-          name: run-tests-ruby-2.6
-          executor: ruby-26
-          requires:
-            - run-tests-ruby-2.5
-      - build:
-          name: run-tests-jruby-92
-          executor: jruby-92
-          requires:
-            - run-tests-ruby-2.6
+      - build: { name: run-tests-ruby-2.4, executor: ruby-24 }
+      - build: { name: run-tests-ruby-2.5, executor: ruby-25 }
+      - build: { name: run-tests-ruby-2.6, executor: ruby-26 }
+      - build: { name: run-tests-jruby-92, executor: jruby-92 }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,7 +1,8 @@
 require 'config_helper'
+require 'securerandom'
 
 describe Elastic::AppSearch::Client do
-  let(:engine_name) { "ruby-client-test-#{Time.now.to_i}" }
+  let(:engine_name) { "ruby-client-test-#{SecureRandom.hex}" }
 
   include_context 'App Search Credentials'
   let(:client) { Elastic::AppSearch::Client.new(client_options) }
@@ -9,7 +10,7 @@ describe Elastic::AppSearch::Client do
   before(:all) do
     # Bootstraps a static engine for 'read-only' options that require indexing
     # across the test suite
-    @static_engine_name = "ruby-client-test-static-#{Time.now.to_i}"
+    @static_engine_name = "ruby-client-test-static-#{SecureRandom.hex}"
     as_api_key = ConfigHelper.get_as_api_key
     as_host_identifier = ConfigHelper.get_as_host_identifier
     as_api_endpoint = ConfigHelper.get_as_api_endpoint


### PR DESCRIPTION
Random engine names were not random enough, test suites were
clobbering one another.

I also made the specs run in parallel again, since it is now safe and
will make CI faster.