### PR TITLE
Improved error message parsing in Exceptions

### DIFF
--- a/lib/elastic/app-search/exceptions.rb
+++ b/lib/elastic/app-search/exceptions.rb
@@ -4,24 +4,14 @@ module Elastic
       attr_reader :errors
 
       def extract_messages(response)
-        if response['errors']
-          if response['errors'].is_a?(Array)
-           return response['errors']
-          else
-           return [response['errors']]
-          end
-        else
-         return [response]
-        end
+        errors_value = response['errors']
+        return errors_value if errors_value && errors_value.is_a?(Array)
+        return [errors_value] if errors_value && !errors_value.is_a?(Array)
+        return [response]
       end
 
       def initialize(response)
-        if response.is_a?(Array)
-          @errors = response.flat_map { |r| extract_messages(r) }
-        else
-          @errors = extract_messages(response)
-        end
-
+        @errors = response.is_a?(Array) ? response.flat_map { |r| extract_messages(r) } : extract_messages(response)
         message = (errors.size == 1) ? "Error: #{errors.first}" : "Errors: #{errors.inspect}"
         super(message)
       end

--- a/lib/elastic/app-search/exceptions.rb
+++ b/lib/elastic/app-search/exceptions.rb
@@ -7,7 +7,7 @@ module Elastic
         errors_value = response['errors']
         return errors_value if errors_value && errors_value.is_a?(Array)
         return [errors_value] if errors_value && !errors_value.is_a?(Array)
-        return [response]
+        [response]
       end
 
       def initialize(response)

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -1,0 +1,69 @@
+describe Elastic::AppSearch::ClientException do
+  describe "when parsing a response body" do
+    describe "and there is an 'errors' property on the response" do
+      it 'will parse a single error message' do
+        expect(Elastic::AppSearch::ClientException.new(
+          { "errors" => [ "Unauthorized action." ] }
+        ).message).to eq("Error: Unauthorized action.")
+      end
+
+      it 'will parse multiple error messages' do
+        expect(Elastic::AppSearch::ClientException.new(
+          { "errors" => [ "Unauthorized action.", "Service unavailable" ] }
+        ).message).to eq("Errors: [\"Unauthorized action.\", \"Service unavailable\"]")
+      end
+
+      it 'will parse when there is a string instead of an array in errors' do
+        expect(Elastic::AppSearch::ClientException.new(
+          { "errors" => "Routing Error. The path you have requested is invalid." }
+        ).message).to eq("Error: Routing Error. The path you have requested is invalid.")
+      end
+    end
+
+    describe "when there is an array of responses" do
+      it 'will parse a single error message' do
+        expect(Elastic::AppSearch::ClientException.new(
+          [
+            { "errors" => [ "Unauthorized action." ] },
+            { "errors" => [ "Service unavailable" ] }
+          ]
+        ).message).to eq("Errors: [\"Unauthorized action.\", \"Service unavailable\"]")
+      end
+
+      it 'will parse multiple error messages' do
+        expect(Elastic::AppSearch::ClientException.new(
+          [
+            { "errors" => [ "Unauthorized action.", "Service unavailable" ] },
+            { "errors" => [ "Another error" ] }
+          ]
+        ).message).to eq("Errors: [\"Unauthorized action.\", \"Service unavailable\", \"Another error\"]")
+      end
+
+      it 'will parse when there is a string instead of an array in errors' do
+        expect(Elastic::AppSearch::ClientException.new(
+          [
+            { "errors" => [ "Unauthorized action.", "Service unavailable" ] },
+            { "errors" => [ "Another error" ] },
+            { "errors" => "Routing Error. The path you have requested is invalid." }
+          ]
+        ).message).to eq("Errors: [\"Unauthorized action.\", \"Service unavailable\", \"Another error\", \"Routing Error. The path you have requested is invalid.\"]")
+      end
+    end
+
+    describe "and there is a single 'error'" do
+      it 'will just return the entire response body' do
+        expect(Elastic::AppSearch::ClientException.new(
+          { "error" => "Unauthorized action." }
+        ).message).to eq("Error: {\"error\"=>\"Unauthorized action.\"}")
+      end
+    end
+
+    describe "and there is a just a string" do
+      it 'will just return the entire response body' do
+        expect(Elastic::AppSearch::ClientException.new(
+          "Unauthorized action."
+        ).message).to eq("Error: Unauthorized action.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Error responses can be in an unpredictable formats in our API.

{ error: "error message" },
{ errors: "error message" },
{ errors: ["error message"] }
"error message"

This logic does its best to parse them correctly. I'd be inclined
to remove this parsing logic in the future, but for a patch I simply
wanted to fix a single case that was broken, which is this case:

{ error: "error message" }

Fixes: https://github.com/swiftype/swiftype-app-search-ruby/issues/50