### PR TITLE
Fix gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To install the gem, execute:
 gem install elastic-app-search
 ```
 
-Or place `gem 'elastic-app-search', '~> 7.3.1'` in your `Gemfile` and run `bundle install`.
+Or place `gem 'elastic-app-search', '~> 7.3.2'` in your `Gemfile` and run `bundle install`.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It also requires a valid `[API_KEY]`, which authenticates requests to the API. Y
 You can find your `[API_KEY]` and your `[HOST_IDENTIFIER]` within the [Credentials](https://app.swiftype.com/as/credentials) menu:
 
 ```ruby
-require 'elastic/app-search'
+require 'elastic-app-search'
 
 client = Elastic::AppSearch::Client.new(:host_identifier => 'host-c5s2mj', :api_key => 'private-mu75psc5egt9ppzuycnc2mc3')
 ```
@@ -60,7 +60,7 @@ The client can be configured to use a managed deploy by using the
 , it can be omitted.
 
 ```ruby
-require 'elastic/app-search'
+require 'elastic-app-search'
 
 client = Elastic::AppSearch::Client.new(:api_key => 'private-mu75psc5egt9ppzuycnc2mc3', :api_endpoint => 'http://localhost:3002/api/as/v1/')
 ```

--- a/lib/elastic-app-search.rb
+++ b/lib/elastic-app-search.rb
@@ -1,0 +1,1 @@
+require 'elastic/app-search'

--- a/lib/elastic/app-search/version.rb
+++ b/lib/elastic/app-search/version.rb
@@ -1,5 +1,5 @@
 module Elastic
   module AppSearch
-    VERSION = '7.3.1'
+    VERSION = '7.3.2'
   end
 end


### PR DESCRIPTION
TL;DR: This PR allows you to *not* have to require 'elastic/app-search' in order to use this client.

Rails calls `Bundler.require` on initialization.

For every gem in Gemfile, `Bundler.require` will require that
gem, by attempting to require according to the gems name.

This means that typically, gems must have a file under `lib` that
corresponds to the name of the gem.

This gem was expecting users to require with `elastic/app-search`,
which did not match the gem name. This means gems had to be
explicitly required in Rails and also is a bit of an anti-pattern for
Ruby.

This fixes that by adding the correct file, so that this gem will be
auto-required by Rails and also available via
`require elastic-app-search`, which remaining backwards compatible with
`require elastic/app-search`.

The way I tested this locally was in a separate project with a `Gemfile` including:
```
gem "elastic-app-search", path:"/Users/jasonstoltzfus/workspace/app-search-ruby"
```

Then in irb, confirming that this constant was available without a `require`
```
Bundler.require
Elastic::AppSearch::Client
```

I also built the corresponding gem and confirmed that `require elastic-app-search` works.
