### PR TITLE
Fixed spec failure

### DIFF
--- a/spec/documents_spec.rb
+++ b/spec/documents_spec.rb
@@ -71,7 +71,7 @@ describe Elastic::AppSearch::Client::Documents do
         it 'should return respective errors in an array of document processing hashes' do
           expected = [
             { 'id' => anything, 'errors' => [] },
-            { 'id' => anything, 'errors' => ['Invalid field type: id must be less than 800 characters'] },
+            { 'id' => anything, 'errors' => [anything] },
           ]
           expect(subject).to(match(expected))
         end


### PR DESCRIPTION
This was causing a spec failure against 7.10.0.

This was due to an error message change.

> "id must be less than 800 characters"

is now

> "Invalid field type: id must be 487 bytes or fewer"

Despite the obvious discrepancy in the message, the behavior has
not changed, the message has simply been updated to correctly
reflect the validation.

Since these specs need to work for Swiftype App Search (For CI) AND
self-managed, I am simply subbing out the exact string for an
`anything` check.